### PR TITLE
VCST-5069: Add warning for empty content in PageIndexDocumentBuilder

### DIFF
--- a/src/VirtoCommerce.Pages.Data/Search/PageIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.Pages.Data/Search/PageIndexDocumentBuilder.cs
@@ -37,6 +37,13 @@ public class PageIndexDocumentBuilder(
                         continue;
                     }
 
+                    if (string.IsNullOrWhiteSpace(page.Content))
+                    {
+                        logger.LogWarning("Skipping page '{PageId}' from provider '{ProviderName}': Content is empty",
+                            page.Id, provider.ProviderName);
+                        continue;
+                    }
+
                     var indexDocument = documentConverter.ToIndexDocument(page);
                     result.Add(indexDocument);
                 }

--- a/tests/VirtoCommerce.Pages.Tests/PageIndexDocumentBuilderTests.cs
+++ b/tests/VirtoCommerce.Pages.Tests/PageIndexDocumentBuilderTests.cs
@@ -35,7 +35,7 @@ public class PageIndexDocumentBuilderTests
     [Fact]
     public async Task GetDocumentsAsync_ProviderReturnsPages_ConvertsToIndexDocuments()
     {
-        var page = new PageDocument { Id = "page1", Title = "Test Page", StoreId = "store1" };
+        var page = new PageDocument { Id = "page1", Title = "Test Page", StoreId = "store1", Content = "{}" };
         var indexDoc = new IndexDocument("page1");
 
         var provider = new Mock<IPageContentProvider>();
@@ -54,8 +54,8 @@ public class PageIndexDocumentBuilderTests
     [Fact]
     public async Task GetDocumentsAsync_MultipleProviders_AggregatesResults()
     {
-        var page1 = new PageDocument { Id = "page1", StoreId = "store1" };
-        var page2 = new PageDocument { Id = "page2", StoreId = "store1" };
+        var page1 = new PageDocument { Id = "page1", StoreId = "store1", Content = "{}" };
+        var page2 = new PageDocument { Id = "page2", StoreId = "store1", Content = "{}" };
 
         var provider1 = new Mock<IPageContentProvider>();
         provider1.Setup(p => p.ProviderName).Returns("CMS1");
@@ -79,7 +79,7 @@ public class PageIndexDocumentBuilderTests
     [Fact]
     public async Task GetDocumentsAsync_ProviderThrows_LogsErrorAndContinues()
     {
-        var page = new PageDocument { Id = "page2", StoreId = "store1" };
+        var page = new PageDocument { Id = "page2", StoreId = "store1", Content = "{}" };
 
         var failingProvider = new Mock<IPageContentProvider>();
         failingProvider.Setup(p => p.ProviderName).Returns("FailingCMS");


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5069
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pages_3.1005.0-pr-17-0271.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation change in indexing that only filters out pages with empty content and adds warnings; limited blast radius and covered by updated tests.
> 
> **Overview**
> `PageIndexDocumentBuilder` now **skips indexing pages with empty/whitespace `Content`**, logging a warning (similar to the existing `StoreId` check) instead of converting them to `IndexDocument`s.
> 
> Tests were updated to populate `PageDocument.Content` in scenarios that expect indexing results, aligning test data with the new validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02710cd71a668cd897650ed4887beb451d987692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->