### PR TITLE
VCST-5163: Stable 15 — Pages (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.Pages.Core/VirtoCommerce.Pages.Core.csproj
+++ b/src/VirtoCommerce.Pages.Core/VirtoCommerce.Pages.Core.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Pages.Data/ExportImport/PagesExportImport.cs
+++ b/src/VirtoCommerce.Pages.Data/ExportImport/PagesExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Linq;
@@ -27,9 +28,9 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
 
         var serializer = new JsonSerializer();
 
-        await jsonWriter.WriteStartObjectAsync();
-        await jsonWriter.WritePropertyNameAsync("Pages");
-        await jsonWriter.WriteStartArrayAsync();
+        await jsonWriter.WriteStartObjectAsync(cancellationToken);
+        await jsonWriter.WritePropertyNameAsync("Pages", cancellationToken);
+        await jsonWriter.WriteStartArrayAsync(cancellationToken);
 
         var criteria = AbstractTypeFactory<PageDocumentSearchCriteria>.TryCreateInstance();
         criteria.Take = BatchSize;
@@ -64,10 +65,10 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
         }
         while (criteria.Skip < totalCount);
 
-        await jsonWriter.WriteEndArrayAsync();
-        await jsonWriter.WriteEndObjectAsync();
+        await jsonWriter.WriteEndArrayAsync(cancellationToken);
+        await jsonWriter.WriteEndObjectAsync(cancellationToken);
 
-        await jsonWriter.FlushAsync();
+        await jsonWriter.FlushAsync(cancellationToken);
     }
 
     public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -82,7 +83,7 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
 
         var serializer = new JsonSerializer();
 
-        while (await jsonReader.ReadAsync())
+        while (await jsonReader.ReadAsync(cancellationToken))
         {
             if (jsonReader.TokenType != JsonToken.PropertyName)
             {
@@ -107,12 +108,12 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
         var progressInfo = new ExportImportProgressInfo { Description = "Importing pages..." };
         var processedCount = 0;
 
-        await jsonReader.ReadAsync(); // StartArray
+        await jsonReader.ReadAsync(cancellationToken); // StartArray
 
         var batch = new PageDocument[BatchSize];
         var batchIndex = 0;
 
-        while (await jsonReader.ReadAsync())
+        while (await jsonReader.ReadAsync(cancellationToken))
         {
             if (jsonReader.TokenType == JsonToken.EndArray)
             {

--- a/src/VirtoCommerce.Pages.Data/ExportImport/PagesExportImport.cs
+++ b/src/VirtoCommerce.Pages.Data/ExportImport/PagesExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -14,7 +15,7 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
 {
     private const int BatchSize = 50;
 
-    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -69,7 +70,7 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
         await jsonWriter.FlushAsync();
     }
 
-    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -101,7 +102,7 @@ public class PagesExportImport(IPageDocumentSearchService searchService)
         JsonTextReader jsonReader,
         JsonSerializer serializer,
         Action<ExportImportProgressInfo> progressCallback,
-        ICancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         var progressInfo = new ExportImportProgressInfo { Description = "Importing pages..." };
         var processedCount = 0;

--- a/src/VirtoCommerce.Pages.Data/VirtoCommerce.Pages.Data.csproj
+++ b/src/VirtoCommerce.Pages.Data/VirtoCommerce.Pages.Data.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Pages.Core\VirtoCommerce.Pages.Core.csproj" />

--- a/src/VirtoCommerce.Pages.Web/Module.cs
+++ b/src/VirtoCommerce.Pages.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -89,13 +90,13 @@ public class Module : IModule, IExportSupport, IImportSupport, IHasConfiguration
         // Nothing to do here
     }
 
-    public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         return _appBuilder.ApplicationServices.GetRequiredService<PagesExportImport>()
             .DoExportAsync(outStream, progressCallback, cancellationToken);
     }
 
-    public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         return _appBuilder.ApplicationServices.GetRequiredService<PagesExportImport>()
             .DoImportAsync(inputStream, progressCallback, cancellationToken);

--- a/src/VirtoCommerce.Pages.Web/module.manifest
+++ b/src/VirtoCommerce.Pages.Web/module.manifest
@@ -4,12 +4,12 @@
   <version>3.1007.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Seo" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Virto Pages</title>

--- a/tests/VirtoCommerce.Pages.Tests/PagesExportImportTests.cs
+++ b/tests/VirtoCommerce.Pages.Tests/PagesExportImportTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -64,15 +65,15 @@ public class PagesExportImportTests
             .ReturnsAsync(new IndexingResult { Items = [] });
 
         var exportImport = new PagesExportImport(_searchServiceMock.Object);
-        var cancellationToken = new Mock<ICancellationToken>();
+        var cancellationToken = CancellationToken.None;
 
         // Export
         using var stream = new MemoryStream();
-        await exportImport.DoExportAsync(stream, _ => { }, cancellationToken.Object);
+        await exportImport.DoExportAsync(stream, _ => { }, cancellationToken);
 
         // Import
         stream.Position = 0;
-        await exportImport.DoImportAsync(stream, _ => { }, cancellationToken.Object);
+        await exportImport.DoImportAsync(stream, _ => { }, cancellationToken);
 
         // Verify
         importedPages.Should().NotBeNull();
@@ -91,10 +92,10 @@ public class PagesExportImportTests
             .ReturnsAsync(new PageDocumentSearchResult { TotalCount = 0, Results = [] });
 
         var exportImport = new PagesExportImport(_searchServiceMock.Object);
-        var cancellationToken = new Mock<ICancellationToken>();
+        var cancellationToken = CancellationToken.None;
 
         using var stream = new MemoryStream();
-        await exportImport.DoExportAsync(stream, _ => { }, cancellationToken.Object);
+        await exportImport.DoExportAsync(stream, _ => { }, cancellationToken);
 
         stream.Position = 0;
         using var reader = new StreamReader(stream);

--- a/tests/VirtoCommerce.Pages.Tests/VirtoCommerce.Pages.Tests.csproj
+++ b/tests/VirtoCommerce.Pages.Tests/VirtoCommerce.Pages.Tests.csproj
@@ -9,7 +9,7 @@
     <UserSecretsId>df261636-736f-470a-8d0a-afa962f435a5</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches platform export/import contracts and long-running JSON I/O cancellation; behavior should match platform 3.1039.0 but regressions could affect backup/restore of pages.
> 
> **Overview**
> **Stable 15** alignment for Virto Pages: bumps **platform** to `3.1039.0` and refreshes **Customer**, **Search**, **Seo**, and **Store** package/manifest dependency versions to match Wave 1–4 packages.
> 
> Export/import is updated for the platform API change from **`ICancellationToken` to `System.Threading.CancellationToken`**: `Module`’s `ExportAsync`/`ImportAsync`, `PagesExportImport`, and Newtonsoft `JsonTextReader`/`JsonTextWriter` async calls now pass the token through so cancellation can propagate during long page export/import.
> 
> Tests use **`CancellationToken.None`** instead of mocking `ICancellationToken`; **coverlet.collector** is bumped to `10.0.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7c13c24e57dd91726e01c41e4040d9a05516d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pages_3.1007.0-pr-18-bf7c.zip